### PR TITLE
Fixes for OTP 22+

### DIFF
--- a/lib/signed_request/signed_uri.ex
+++ b/lib/signed_request/signed_uri.ex
@@ -63,8 +63,7 @@ defmodule SignedRequest.SignedURI do
     |> create_hmac
   end
   defp create_hmac(params) when is_binary(params) do
-    :sha256
-    |> :crypto.hmac(secret_key(), params)
+    :crypto.mac(:hmac, :sha256, secret_key(), params)
     |> Base.encode16
     |> String.downcase
   end

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule SignedRequest.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     # Specify extra applications you'll use from Erlang/Elixir
-    [extra_applications: [:logger]]
+    [extra_applications: [:logger, :crypto]]
   end
 
   def package do

--- a/test/signed_request/signed_uri_test.exs
+++ b/test/signed_request/signed_uri_test.exs
@@ -11,8 +11,7 @@ defmodule SignedRequest.SignedURITest do
 
   def hmac(string) do
     secret = Application.get_env(:signed_request, :secret_key)
-    :sha256
-    |> :crypto.hmac(secret, string)
+    :crypto.mac(:hmac, :sha256, secret, string)
     |> Base.encode16
     |> String.downcase
   end


### PR DESCRIPTION
- `:crypto.hmac` is deprecated and has been removed in OTP 24.
- Add  `:crypto` to the extra apps so it will be packaged with the app